### PR TITLE
Create The path integral formulation of Alcubierre drive.md

### DIFF
--- a/The path integral formulation of Alcubierre drive.md
+++ b/The path integral formulation of Alcubierre drive.md
@@ -1,0 +1,78 @@
+# The path integral formulation of the **Alcubierre drive** 
+
+The path integral formulation of the **Alcubierre drive** requires integrating over all possible spacetime geometries that contribute to the warp bubble's evolution. This involves **quantum gravity** and is deeply tied to the semiclassical treatment of general relativity. Let's break this down mathematically.
+
+### **1. Path Integral in General Relativity**
+In quantum field theory, the **path integral formulation** of a system is given by:
+
+\[
+Z = \int \mathcal{D}g_{\mu\nu} e^{i S[g_{\mu\nu}] / \hbar}
+\]
+
+where:
+- \( Z \) is the partition function.
+- \( \mathcal{D}g_{\mu\nu} \) represents integration over all possible metric configurations.
+- \( S[g_{\mu\nu}] \) is the Einstein-Hilbert action:
+
+\[
+S = \frac{1}{16\pi G} \int d^4x \sqrt{-g} (R + \mathcal{L}_{\text{matter}})
+\]
+
+where \( R \) is the Ricci scalar and \( \mathcal{L}_{\text{matter}} \) describes exotic matter needed for the Alcubierre drive.
+
+### **2. Alcubierre Metric**
+The Alcubierre metric is:
+
+\[
+ds^2 = -c^2 dt^2 + (dx - v_s f(r_s) dt)^2 + dy^2 + dz^2
+\]
+
+where:
+- \( v_s \) is the speed of the bubble.
+- \( f(r_s) \) is the warp function.
+- \( r_s = \sqrt{(x - x_s(t))^2 + y^2 + z^2} \) is the distance to the center of the warp bubble.
+
+This metric **violates energy conditions**, requiring **exotic matter** (negative energy density), which complicates the path integral.
+
+### **3. Path Integral for the Warp Bubble**
+To compute the path integral for the Alcubierre drive, we must evaluate:
+
+\[
+Z = \int \mathcal{D}g_{\mu\nu} e^{i S[g_{\mu\nu}] / \hbar}
+\]
+
+For semiclassical quantum gravity, we expand around a **background spacetime**:
+
+\[
+g_{\mu\nu} = g_{\mu\nu}^{\text{bubble}} + h_{\mu\nu}
+\]
+
+where \( h_{\mu\nu} \) represents quantum fluctuations. The action expands as:
+
+\[
+S = S_{\text{bubble}} + \frac{1}{2} \int d^4x \sqrt{-g} h_{\mu\nu} \mathcal{O}^{\mu\nu\alpha\beta} h_{\alpha\beta} + \dots
+\]
+
+where \( \mathcal{O} \) is a differential operator acting on metric perturbations. The propagator is:
+
+\[
+\langle h_{\mu\nu} h_{\alpha\beta} \rangle = \mathcal{O}^{-1}_{\mu\nu\alpha\beta}
+\]
+
+Integrating out \( h_{\mu\nu} \), the result is:
+
+\[
+Z \approx e^{i S_{\text{bubble}} / \hbar} \det(\mathcal{O})^{-1/2}
+\]
+
+The path integral is dominated by the **saddle point contribution** from the classical action \( S_{\text{bubble}} \), meaning the stability and energy requirements of the Alcubierre metric determine whether the path integral converges.
+
+### **4. Issues and Speculations**
+1. **Negative Energy Contributions**: The path integral may diverge due to **exotic matter** violating the energy conditions.
+2. **Quantum Gravity Corrections**: A full **string-theoretic** or **loop quantum gravity** approach is needed to resolve divergences.
+3. **Topological Contributions**: If the warp bubble connects distant points in spacetime non-trivially, quantum gravity effects like Euclidean wormholes or topology change might influence the path integral.
+
+### **5. Conclusion**
+A full computation of the path integral for the Alcubierre drive would require a **non-perturbative** approach to quantum gravity. However, semiclassical methods suggest that the dominant contribution comes from the classical warp bubble metric, modified by fluctuations and quantum stress-energy corrections. Whether these corrections stabilize or destroy the drive remains an **open question**.
+
+Would you like a more in-depth approach using specific quantum gravity models (e.g., string theory, loop quantum gravity)?


### PR DESCRIPTION
# The path integral formulation of the **Alcubierre drive** 

The path integral formulation of the **Alcubierre drive** requires integrating over all possible spacetime geometries that contribute to the warp bubble's evolution. This involves **quantum gravity** and is deeply tied to the semiclassical treatment of general relativity. Let's break this down mathematically.

### **1. Path Integral in General Relativity**
In quantum field theory, the **path integral formulation** of a system is given by:

\[
Z = \int \mathcal{D}g_{\mu\nu} e^{i S[g_{\mu\nu}] / \hbar} \]

where:
- \( Z \) is the partition function.
- \( \mathcal{D}g_{\mu\nu} \) represents integration over all possible metric configurations.
- \( S[g_{\mu\nu}] \) is the Einstein-Hilbert action:

\[
S = \frac{1}{16\pi G} \int d^4x \sqrt{-g} (R + \mathcal{L}_{\text{matter}}) \]

where \( R \) is the Ricci scalar and \( \mathcal{L}_{\text{matter}} \) describes exotic matter needed for the Alcubierre drive.

### **2. Alcubierre Metric**
The Alcubierre metric is:

\[
ds^2 = -c^2 dt^2 + (dx - v_s f(r_s) dt)^2 + dy^2 + dz^2 \]

where:
- \( v_s \) is the speed of the bubble.
- \( f(r_s) \) is the warp function.
- \( r_s = \sqrt{(x - x_s(t))^2 + y^2 + z^2} \) is the distance to the center of the warp bubble.

This metric **violates energy conditions**, requiring **exotic matter** (negative energy density), which complicates the path integral.

### **3. Path Integral for the Warp Bubble**
To compute the path integral for the Alcubierre drive, we must evaluate:

\[
Z = \int \mathcal{D}g_{\mu\nu} e^{i S[g_{\mu\nu}] / \hbar} \]

For semiclassical quantum gravity, we expand around a **background spacetime**:

\[
g_{\mu\nu} = g_{\mu\nu}^{\text{bubble}} + h_{\mu\nu} \]

where \( h_{\mu\nu} \) represents quantum fluctuations. The action expands as:

\[
S = S_{\text{bubble}} + \frac{1}{2} \int d^4x \sqrt{-g} h_{\mu\nu} \mathcal{O}^{\mu\nu\alpha\beta} h_{\alpha\beta} + \dots \]

where \( \mathcal{O} \) is a differential operator acting on metric perturbations. The propagator is:

\[
\langle h_{\mu\nu} h_{\alpha\beta} \rangle = \mathcal{O}^{-1}_{\mu\nu\alpha\beta} \]

Integrating out \( h_{\mu\nu} \), the result is:

\[
Z \approx e^{i S_{\text{bubble}} / \hbar} \det(\mathcal{O})^{-1/2} \]

The path integral is dominated by the **saddle point contribution** from the classical action \( S_{\text{bubble}} \), meaning the stability and energy requirements of the Alcubierre metric determine whether the path integral converges.

### **4. Issues and Speculations**
1. **Negative Energy Contributions**: The path integral may diverge due to **exotic matter** violating the energy conditions.
2. **Quantum Gravity Corrections**: A full **string-theoretic** or **loop quantum gravity** approach is needed to resolve divergences.
3. **Topological Contributions**: If the warp bubble connects distant points in spacetime non-trivially, quantum gravity effects like Euclidean wormholes or topology change might influence the path integral.

### **5. Conclusion**
A full computation of the path integral for the Alcubierre drive would require a **non-perturbative** approach to quantum gravity. However, semiclassical methods suggest that the dominant contribution comes from the classical warp bubble metric, modified by fluctuations and quantum stress-energy corrections. Whether these corrections stabilize or destroy the drive remains an **open question**.

Would you like a more in-depth approach using specific quantum gravity models (e.g., string theory, loop quantum gravity)?