### PR TITLE
Create No cloning Theorem.md

### DIFF
--- a/No cloning Theorem.md
+++ b/No cloning Theorem.md
@@ -1,0 +1,44 @@
+# no cloning theorem 
+
+- if everywhere is random, how can there be anything be the same
+
+### **PMOS and NMOS Voltage Operation Range**
+
+PMOS (P-channel Metal-Oxide-Semiconductor) and NMOS (N-channel Metal-Oxide-Semiconductor) transistors have different voltage operation characteristics based on their threshold voltages and biasing conditions.
+
+---
+
+### **1. NMOS (N-channel MOSFET)**
+- **Operates with a positive drain-source voltage (V_DS) and positive gate-source voltage (V_GS).**
+- **Threshold voltage**: \( V_{th} \) (typically **positive** for NMOS).
+- **Voltage ranges:**
+  - **Cutoff Region (OFF State)**: \( V_{GS} < V_{th} \)
+  - **Linear (Triode) Region**: \( V_{GS} > V_{th} \) and \( V_{DS} < V_{GS} - V_{th} \)
+  - **Saturation (Active) Region**: \( V_{GS} > V_{th} \) and \( V_{DS} \geq V_{GS} - V_{th} \)
+
+For a typical **5V NMOS**, the threshold voltage might be around **0.7V to 1.5V**.
+
+---
+
+### **2. PMOS (P-channel MOSFET)**
+- **Operates with a negative drain-source voltage (V_DS) and negative gate-source voltage (V_GS).**
+- **Threshold voltage**: \( V_{th} \) (typically **negative** for PMOS).
+- **Voltage ranges:**
+  - **Cutoff Region (OFF State)**: \( V_{SG} < |V_{th}| \) (equivalent to \( V_{GS} > V_{th} \))
+  - **Linear (Triode) Region**: \( V_{SG} > |V_{th}| \) and \( |V_{SD}| < V_{SG} - |V_{th}| \) (equivalent to \( V_{GS} < V_{th} \) and \( V_{DS} > V_{GS} - V_{th} \))
+  - **Saturation (Active) Region**: \( V_{SG} > |V_{th}| \) and \( |V_{SD}| \geq V_{SG} - |V_{th}| \) (equivalent to \( V_{GS} < V_{th} \) and \( V_{DS} \leq V_{GS} - V_{th} \))
+
+For a typical **5V PMOS**, the threshold voltage might be around **-0.7V to -1.5V**.
+
+---
+
+### **Summary**
+| Type  | Cutoff Condition  | Linear Region  | Saturation Region  |
+|--------|------------------|---------------|-------------------|
+| **NMOS** | \( V_{GS} < V_{th} \)  | \( V_{GS} > V_{th} \) and \( V_{DS} < V_{GS} - V_{th} \) | \( V_{GS} > V_{th} \) and \( V_{DS} \geq V_{GS} - V_{th} \) |
+| **PMOS** | \( V_{SG} < |V_{th}| \) or \( V_{GS} > V_{th} \) | \( V_{SG} > |V_{th}| \) and \( |V_{SD}| < V_{SG} - |V_{th}| \) | \( V_{SG} > |V_{th}| \) and \( |V_{SD}| \geq V_{SG} - |V_{th}| \) |
+
+- **For NMOS**, increasing \( V_{GS} \) (above threshold) turns the transistor ON.
+- **For PMOS**, decreasing \( V_{GS} \) (below threshold, more negative) turns the transistor ON.
+
+Would you like an example with a specific voltage range (e.g., **1.8V, 3.3V, or 5V technology**)?


### PR DESCRIPTION
```markdown
# no cloning theorem 

- if everywhere is random, how can there be anything be the same

### **PMOS and NMOS Voltage Operation Range**

PMOS (P-channel Metal-Oxide-Semiconductor) and NMOS (N-channel Metal-Oxide-Semiconductor) transistors have different voltage operation characteristics based on their threshold voltages and biasing conditions.

---

### **1. NMOS (N-channel MOSFET)**
- **Operates with a positive drain-source voltage (V_DS) and positive gate-source voltage (V_GS).**
- **Threshold voltage**: \( V_{th} \) (typically **positive** for NMOS).
- **Voltage ranges:**
  - **Cutoff Region (OFF State)**: \( V_{GS} < V_{th} \)
  - **Linear (Triode) Region**: \( V_{GS} > V_{th} \) and \( V_{DS} < V_{GS} - V_{th} \)
  - **Saturation (Active) Region**: \( V_{GS} > V_{th} \) and \( V_{DS} \geq V_{GS} - V_{th} \)

For a typical **5V NMOS**, the threshold voltage might be around **0.7V to 1.5V**.

---

### **2. PMOS (P-channel MOSFET)**
- **Operates with a negative drain-source voltage (V_DS) and negative gate-source voltage (V_GS).**
- **Threshold voltage**: \( V_{th} \) (typically **negative** for PMOS).
- **Voltage ranges:**
  - **Cutoff Region (OFF State)**: \( V_{SG} < |V_{th}| \) (equivalent to \( V_{GS} > V_{th} \))
  - **Linear (Triode) Region**: \( V_{SG} > |V_{th}| \) and \( |V_{SD}| < V_{SG} - |V_{th}| \) (equivalent to \( V_{GS} < V_{th} \) and \( V_{DS} > V_{GS} - V_{th} \))
  - **Saturation (Active) Region**: \( V_{SG} > |V_{th}| \) and \( |V_{SD}| \geq V_{SG} - |V_{th}| \) (equivalent to \( V_{GS} < V_{th} \) and \( V_{DS} \leq V_{GS} - V_{th} \))

For a typical **5V PMOS**, the threshold voltage might be around **-0.7V to -1.5V**.

---

### **Summary**
| Type  | Cutoff Condition  | Linear Region  | Saturation Region  |
|--------|------------------|---------------|-------------------|
| **NMOS** | \( V_{GS} < V_{th} \)  | \( V_{GS} > V_{th} \) and \( V_{DS} < V_{GS} - V_{th} \) | \( V_{GS} > V_{th} \) and \( V_{DS} \geq V_{GS} - V_{th} \) |
| **PMOS** | \( V_{SG} < |V_{th}| \) or \( V_{GS} > V_{th} \) | \( V_{SG} > |V_{th}| \) and \( |V_{SD}| < V_{SG} - |V_{th}| \) | \( V_{SG} > |V_{th}| \) and \( |V_{SD}| \geq V_{SG} - |V_{th}| \) |

- **For NMOS**, increasing \( V_{GS} \) (above threshold) turns the transistor ON.
- **For PMOS**, decreasing \( V_{GS} \) (below threshold, more negative) turns the transistor ON.

Would you like an example with a specific voltage range (e.g., **1.8V, 3.3V, or 5V technology**)?
```